### PR TITLE
ZON-2429: Deprecate homepage snapshot

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ zeit.content.cp changes
 3.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Deprecate homepage snapshot image (ZON-2429).
 
 
 3.4.0 (2015-11-12)

--- a/src/zeit/content/cp/browser/form.py
+++ b/src/zeit/content/cp/browser/form.py
@@ -19,7 +19,7 @@ class FormBase(object):
                 'keywords', 'push_news')
         + zope.formlib.form.FormFields(
             zeit.content.cp.interfaces.ICenterPage).select(
-            'type', 'header_image', 'snapshot', 'topiclink_title',
+            'type', 'header_image', 'topiclink_title',
             'topiclink_label_1', 'topiclink_url_1',
             'topiclink_label_2', 'topiclink_url_2',
             'topiclink_label_3', 'topiclink_url_3',

--- a/src/zeit/content/cp/centerpage.py
+++ b/src/zeit/content/cp/centerpage.py
@@ -76,10 +76,6 @@ class CenterPage(zeit.cms.content.metadata.CommonMetadata):
         '.head.header_image',
         xml_reference_name='image', attributes=('base-id', 'src'))
 
-    snapshot = zeit.cms.content.property.SingleResource(
-        '.head.snapshot',
-        xml_reference_name='image', attributes=('base-id', 'src'))
-
     topiclink_title = zeit.cms.content.property.ObjectPathProperty(
         '.head.topiclinks.topiclink_title',
         zeit.content.cp.interfaces.ICenterPage['topiclink_title'])
@@ -307,9 +303,9 @@ def cms_content_iter(context):
 @zope.interface.implementer(zeit.cms.relation.interfaces.IReferenceProvider)
 def cp_references(context):
     cms_content = list(zeit.content.cp.interfaces.ICMSContentIterable(context))
-    images = [context.header_image, context.snapshot]
-    images = [x for x in images if x]
-    return cms_content + images
+    if context.header_image:
+        cms_content.append(context.header_image)
+    return cms_content
 
 
 @zope.component.adapter(
@@ -320,7 +316,6 @@ def update_centerpage_on_checkin(context, event):
         context.updateMetadata(content)
 
     context.header_image = context.header_image
-    context.snapshot = context.snapshot
 
 
 @zope.component.adapter(

--- a/src/zeit/content/cp/interfaces.py
+++ b/src/zeit/content/cp/interfaces.py
@@ -45,11 +45,6 @@ class ICenterPage(zeit.cms.content.interfaces.ICommonMetadata,
         required=False,
         source=zeit.content.image.interfaces.imageSource)
 
-    snapshot = zope.schema.Choice(
-        title=_('Snapshot (HP only)'),
-        required=False,
-        source=zeit.content.image.interfaces.imageSource)
-
     topiclink_title = zope.schema.TextLine(
         title=_('Name for topiclinks'),
         required=False)


### PR DESCRIPTION
Friends with https://github.com/ZeitOnline/zeit.locales/pull/1
