### PR TITLE
ZON-2826: Add rawtext module for cp

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,8 @@ zeit.content.cp changes
 3.5.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add a rawtext block which allows references of plain text
+  or plain text input form
 
 
 3.5.3 (2016-02-22)

--- a/src/zeit/content/cp/blocks/configure.zcml
+++ b/src/zeit/content/cp/blocks/configure.zcml
@@ -190,6 +190,22 @@
     factory=".frame.FrameBlock"
     />
 
+  <!-- Raw block -->
+  <class class=".rawtext.RawTextBlock">
+    <require
+      interface="..interfaces.IRawTextBlock"
+      permission="zope.View" />
+    <require
+      set_schema="..interfaces.IRawTextBlock"
+      permission="zeit.EditContent"/>
+  </class>
+
+  <adapter
+    provides="zeit.edit.interfaces.IElement"
+    name="rawtext"
+    factory=".rawtext.RawTextBlock"
+    />
+
   <!-- Headerimage block -->
   <class class=".headerimage.HeaderImageBlock">
     <require

--- a/src/zeit/content/cp/blocks/rawtext.py
+++ b/src/zeit/content/cp/blocks/rawtext.py
@@ -1,0 +1,43 @@
+from zeit.content.cp.i18n import MessageFactory as _
+import lxml.objectify
+import zeit.content.cp.blocks.block
+import zeit.content.cp.interfaces
+import zeit.edit.block
+import zope.container.interfaces
+import zope.interface
+
+
+class RawTextXMLBlock(zeit.content.cp.blocks.block.Block):
+
+    zope.interface.implements(
+        zeit.content.cp.interfaces.IXMLBlock,
+        zope.container.interfaces.IContained)
+
+
+class RawTextXMLBlockFactory(zeit.edit.block.TypeOnAttributeElementFactory):
+
+    zope.component.adapts(zeit.content.cp.interfaces.IArea)
+    element_type = module = 'rawtext'
+    title = _('Raw Text block')
+
+    def get_xml(self):
+        container = super(RawTextXMLBlockFactory, self).get_xml()
+
+        # NEED CDATA HANDLING HERE
+        raw = lxml.objectify.E.raw(u'\n\n\n')
+        lxml.objectify.deannotate(raw)
+        container.append(raw)
+        return container
+
+
+class RawTextBlock(zeit.content.cp.blocks.block.Block):
+
+    zope.interface.implements(zeit.content.cp.interfaces.IRawTextBlock)
+
+    raw = zeit.cms.content.reference.SingleResource('.rawtext','related')
+
+
+zeit.edit.block.register_element_factory(
+    [zeit.content.cp.interfaces.IArea],
+    'rawtext', _('raw text block'))
+

--- a/src/zeit/content/cp/blocks/rawtext.py
+++ b/src/zeit/content/cp/blocks/rawtext.py
@@ -16,6 +16,16 @@ class RawTextBlock(zeit.content.cp.blocks.block.Block):
     text = zeit.cms.content.property.ObjectPathProperty(
         '.text', zeit.content.cp.interfaces.IRawTextBlock['text'])
 
+    @property
+    def raw_code(self):
+        if self.text_reference:
+            return self.text_reference.text
+
+        if self.text:
+            return self.text
+
+        return ''
+
 
 zeit.edit.block.register_element_factory(
     [zeit.content.cp.interfaces.IArea],

--- a/src/zeit/content/cp/blocks/rawtext.py
+++ b/src/zeit/content/cp/blocks/rawtext.py
@@ -7,34 +7,14 @@ import zope.container.interfaces
 import zope.interface
 
 
-class RawTextXMLBlock(zeit.content.cp.blocks.block.Block):
-
-    zope.interface.implements(
-        zeit.content.cp.interfaces.IXMLBlock,
-        zope.container.interfaces.IContained)
-
-
-class RawTextXMLBlockFactory(zeit.edit.block.TypeOnAttributeElementFactory):
-
-    zope.component.adapts(zeit.content.cp.interfaces.IArea)
-    element_type = module = 'rawtext'
-    title = _('Raw Text block')
-
-    def get_xml(self):
-        container = super(RawTextXMLBlockFactory, self).get_xml()
-
-        # NEED CDATA HANDLING HERE
-        raw = lxml.objectify.E.raw(u'\n\n\n')
-        lxml.objectify.deannotate(raw)
-        container.append(raw)
-        return container
-
-
 class RawTextBlock(zeit.content.cp.blocks.block.Block):
 
     zope.interface.implements(zeit.content.cp.interfaces.IRawTextBlock)
 
-    raw = zeit.cms.content.reference.SingleResource('.rawtext','related')
+    text_reference = zeit.cms.content.reference.SingleResource(
+        '.text_reference','related')
+    text = zeit.cms.content.property.ObjectPathProperty(
+        '.text', zeit.content.cp.interfaces.IRawTextBlock['text'])
 
 
 zeit.edit.block.register_element_factory(

--- a/src/zeit/content/cp/browser/blocks/configure.zcml
+++ b/src/zeit/content/cp/browser/blocks/configure.zcml
@@ -102,6 +102,7 @@
   <include file="fullgraphical.zcml" />
   <include file="frame.zcml" />
   <include file="headerimage.zcml" />
+  <include file="rawtext.zcml" />
   <include file="markup.zcml" />
   <include file="cardstack.zcml" />
 

--- a/src/zeit/content/cp/browser/blocks/layout.rawtext.content.pt
+++ b/src/zeit/content/cp/browser/blocks/layout.rawtext.content.pt
@@ -1,0 +1,10 @@
+<div i18n:domain="zeit.cms">
+  <div class="header">
+    <tal:block condition="context/supertitle">
+    <span class="supertitle" tal:content="context/supertitle"/><br/>
+    </tal:block>
+  </div>
+
+  <div class="cpextra-title">RAW Code</div>
+  <div tal:condition="context/raw" class="xml-block" tal:content="view/raw_code"/>
+</div>

--- a/src/zeit/content/cp/browser/blocks/layout.rawtext.content.pt
+++ b/src/zeit/content/cp/browser/blocks/layout.rawtext.content.pt
@@ -5,6 +5,6 @@
     </tal:block>
   </div>
 
-  <div class="cpextra-title">RAW Code</div>
-  <div tal:condition="context/raw" class="xml-block" tal:content="view/raw_code"/>
+  <div class="rawtext-title">RAW Code</div>
+  <div class="rawtext-content" tal:content="view/raw_code"/>
 </div>

--- a/src/zeit/content/cp/browser/blocks/rawtext.py
+++ b/src/zeit/content/cp/browser/blocks/rawtext.py
@@ -16,4 +16,10 @@ class Display(zeit.cms.browser.view.Base):
 
     @property
     def raw_code(self):
-        return self.context.raw.text
+        if self.context.text_reference:
+            return self.context.text_reference.text
+
+        if self.context.text:
+            return self.context.text
+
+        return '<code />'

--- a/src/zeit/content/cp/browser/blocks/rawtext.py
+++ b/src/zeit/content/cp/browser/blocks/rawtext.py
@@ -16,10 +16,4 @@ class Display(zeit.cms.browser.view.Base):
 
     @property
     def raw_code(self):
-        if self.context.text_reference:
-            return self.context.text_reference.text
-
-        if self.context.text:
-            return self.context.text
-
-        return '<code />'
+        return self.context.raw_code or '<code />'

--- a/src/zeit/content/cp/browser/blocks/rawtext.py
+++ b/src/zeit/content/cp/browser/blocks/rawtext.py
@@ -1,0 +1,19 @@
+import zeit.cms.browser.view
+import zeit.content.cp.browser.blocks.block
+import zeit.content.cp.interfaces
+import zope.formlib.form
+import lxml.etree
+
+
+class EditProperties(zeit.content.cp.browser.blocks.block.EditCommon):
+
+    form_fields = zope.formlib.form.Fields(
+        zeit.content.cp.interfaces.IRawTextBlock).omit(
+            *list(zeit.content.cp.interfaces.IBlock))
+
+
+class Display(zeit.cms.browser.view.Base):
+
+    @property
+    def raw_code(self):
+        return self.context.raw.text

--- a/src/zeit/content/cp/browser/blocks/rawtext.zcml
+++ b/src/zeit/content/cp/browser/blocks/rawtext.zcml
@@ -1,0 +1,26 @@
+<configure
+  xmlns="http://namespaces.zope.org/zope"
+  xmlns:browser="http://namespaces.zope.org/browser">
+
+  <browser:viewlet
+    for="zeit.content.cp.interfaces.IRawTextBlock"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    view="zope.interface.Interface"
+    manager="..interfaces.IEditorContentViewletManager"
+    name="contents"
+    class=".rawtext.Display"
+    template="layout.rawtext.content.pt"
+    permission="zeit.EditContent"
+    weight="0"
+    />
+
+  <browser:page
+    for="zeit.content.cp.interfaces.IRawTextBlock"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    name="edit-properties"
+    class=".rawtext.EditProperties"
+    permission="zeit.EditContent"
+    />
+
+
+</configure>

--- a/src/zeit/content/cp/browser/blocks/tests/test_rawtext.py
+++ b/src/zeit/content/cp/browser/blocks/tests/test_rawtext.py
@@ -1,0 +1,61 @@
+import zeit.cms.testing
+import zeit.content.cp
+import zeit.content.cp.centerpage
+import zeit.content.text.text
+
+
+class TestRawText(zeit.cms.testing.BrowserTestCase):
+
+    layer = zeit.content.cp.testing.ZCML_LAYER
+
+    def setUp(self):
+        super(TestRawText, self).setUp()
+        with zeit.cms.testing.site(self.getRootFolder()):
+            self.centerpage = zeit.content.cp.centerpage.CenterPage()
+            self.centerpage['lead'].create_item('rawtext')
+            self.repository['centerpage'] = self.centerpage
+
+            self.plaintext = zeit.content.text.text.Text()
+            self.plaintext.text = '<rawcode_reference />'
+            self.repository['plaintext'] = self.plaintext
+
+        b = self.browser
+        b.open(
+            'http://localhost/++skin++vivi/repository/centerpage/@@checkout')
+        b.open('contents')
+        self.content_url = b.url
+
+    def test_can_create_rawtext_module_via_drag_n_drop_from_sidebar(self):
+        b = self.browser
+        self.assertEqual(1, b.contents.count('type-rawtext'))
+        b.open('informatives/@@landing-zone-drop-module?block_type=rawtext')
+        b.open(self.content_url)
+        self.assertEqual(2, b.contents.count('type-rawtext'))
+
+    def test_rawtext_is_edited(self):
+        b = self.browser
+        b.getLink('Edit block properties', index=0).click()
+        b.getControl('Contents').value = '<rawcode_text>'
+        b.getControl('Apply').click()
+        b.open(self.content_url)
+        self.assertEllipsis('...&lt;rawcode_text...', b.contents)
+        b.getLink('Edit block properties', index=0).click()
+        self.assertEqual(
+            '<rawcode_text>',b.getControl('Contents').value.strip())
+
+    def test_rawtext_is_referenced(self):
+        b = self.browser
+        b.getLink('Edit block properties', index=0).click()
+        b.getControl('RawText').value = self.plaintext.uniqueId
+        b.getControl('Apply').click()
+        b.open(self.content_url)
+        self.assertEllipsis('...&lt;rawcode_reference...', b.contents)
+
+    def test_rawtext_reference_should_be_preferred(self):
+        b = self.browser
+        b.getLink('Edit block properties', index=0).click()
+        b.getControl('Contents').value = '<rawcode_text>'
+        b.getControl('RawText').value = self.plaintext.uniqueId
+        b.getControl('Apply').click()
+        b.open(self.content_url)
+        self.assertEllipsis('...&lt;rawcode_reference...', b.contents)

--- a/src/zeit/content/cp/browser/blocks/tests/test_rawtext.py
+++ b/src/zeit/content/cp/browser/blocks/tests/test_rawtext.py
@@ -59,3 +59,12 @@ class TestRawText(zeit.cms.testing.BrowserTestCase):
         b.getControl('Apply').click()
         b.open(self.content_url)
         self.assertEllipsis('...&lt;rawcode_reference...', b.contents)
+
+    def test_rawtext_should_display_default_if_empty(self):
+        b = self.browser
+        b.getLink('Edit block properties', index=0).click()
+        b.getControl('Contents').value = ''
+        b.getControl('RawText').value = ''
+        b.getControl('Apply').click()
+        b.open(self.content_url)
+        self.assertEllipsis('...&lt;code...', b.contents)

--- a/src/zeit/content/cp/browser/resources/editor.css
+++ b/src/zeit/content/cp/browser/resources/editor.css
@@ -384,19 +384,23 @@ margin-top: 4px;
 
 .block-title,
 .block-item,
+.rawtext-content,
+.rawtext-title,
 .cpextra-id,
 .cpextra-title {
   text-align: center;
 }
 
 .block-title,
-.cpextra-title {
+.cpextra-title,
+.rawtext-title {
   margin: 2em 2em 0.5em 2em;
   text-transform: uppercase;
 }
 
 .block-item,
-.cpextra-id {
+.cpextra-id,
+.rawtext-content {
   margin: 0 0 2em 0;
 }
 

--- a/src/zeit/content/cp/ftesting.zcml
+++ b/src/zeit/content/cp/ftesting.zcml
@@ -10,6 +10,9 @@
   <include package="zeit.content.cp" />
   <include package="zeit.content.cp.browser" />
 
+  <include package="zeit.content.text" />
+  <include package="zeit.content.text.browser" />
+
   <include package="zeit.content.image" />
   <include package="zeit.content.image.browser" />
 

--- a/src/zeit/content/cp/interfaces.py
+++ b/src/zeit/content/cp/interfaces.py
@@ -875,13 +875,11 @@ class IRawTextBlock(IBlock):
 
     text_reference = zope.schema.Choice(
         title=_('RawText'),
-        description=_("Drag text content here"),
         required=False,
         source=zeit.content.text.interfaces.textSource)
 
     text = zope.schema.Text(
         title=_('Contents'),
-        description=_('Use plain text'),
         required=False)
 
     raw_code = zope.interface.Attribute('Raw code from text or text_reference')

--- a/src/zeit/content/cp/interfaces.py
+++ b/src/zeit/content/cp/interfaces.py
@@ -884,6 +884,8 @@ class IRawTextBlock(IBlock):
         description=_('Use plain text'),
         required=False)
 
+    raw_code = zope.interface.Attribute('Raw code from text or text_reference')
+
 
 class IFrameBlock(IBlock):
 

--- a/src/zeit/content/cp/interfaces.py
+++ b/src/zeit/content/cp/interfaces.py
@@ -873,11 +873,16 @@ class IRenderedXML(zope.interface.Interface):
 
 class IRawTextBlock(IBlock):
 
-    raw = zope.schema.Choice(
+    text_reference = zope.schema.Choice(
         title=_('RawText'),
         description=_("Drag text content here"),
         required=False,
         source=zeit.content.text.interfaces.textSource)
+
+    text = zope.schema.Text(
+        title=_('Contents'),
+        description=_('Use plain text'),
+        required=False)
 
 
 class IFrameBlock(IBlock):

--- a/src/zeit/content/cp/interfaces.py
+++ b/src/zeit/content/cp/interfaces.py
@@ -17,6 +17,7 @@ import zeit.content.cp.layout
 import zeit.content.cp.source
 import zeit.content.image.interfaces
 import zeit.content.quiz.source
+import zeit.content.text.interfaces
 import zeit.content.video.interfaces
 import zeit.edit.interfaces
 import zope.i18n
@@ -868,6 +869,15 @@ class ILeadTimeWorklist(zope.interface.Interface):
 
 class IRenderedXML(zope.interface.Interface):
     """Recursively converts a CenterPage to an lxml tree."""
+
+
+class IRawTextBlock(IBlock):
+
+    raw = zope.schema.Choice(
+        title=_('RawText'),
+        description=_("Drag text content here"),
+        required=False,
+        source=zeit.content.text.interfaces.textSource)
 
 
 class IFrameBlock(IBlock):


### PR DESCRIPTION
This is a rawtext module to be used in the CP-Editor. It allows to reference plaintext resources or to type in raw code directly

(needs actual version of zeit.content.text)
