### PR TITLE
ZON-2898: Move hex_literal to zeit.cms

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ zeit.content.cp changes
 3.5.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Move ``hex_literal`` to zeit.cms (ZON-2898).
 
 
 3.5.5 (2016-03-10)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'setuptools',
         'xml-compare',
         'zc.sourcefactory',
-        'zeit.cms>=2.64.0.dev0',
+        'zeit.cms>=2.67.0.dev0',
         'zeit.content.image>=2.5.1.dev0',
         'zeit.content.quiz>=0.4.2',
         'zeit.content.text>=2.0.2.dev0',

--- a/src/zeit/content/cp/interfaces.py
+++ b/src/zeit/content/cp/interfaces.py
@@ -202,15 +202,6 @@ class IRegion(
     zope.interface.invariant(zeit.edit.interfaces.unique_name_invariant)
 
 
-def hex_literal(value):
-    try:
-        int(value, base=16)
-    except ValueError:
-        raise zeit.cms.interfaces.ValidationError(_("Invalid hex literal"))
-    else:
-        return True
-
-
 class BelowAreaSource(
         zc.sourcefactory.contextual.BasicContextualSourceFactory):
     """All IAreas of this CenterPage below the current one."""
@@ -505,7 +496,7 @@ class IBlock(IElement, zeit.edit.interfaces.IBlock):
     background_color = zope.schema.TextLine(
         title=_("Background color (ZMO only)"),
         required=False,
-        max_length=6, constraint=hex_literal)
+        max_length=6, constraint=zeit.cms.content.interfaces.hex_literal)
 
 #
 # Teaser block (aka teaser list)


### PR DESCRIPTION
https://github.com/ZeitOnline/zeit.content.image/pull/4
https://github.com/ZeitOnline/zeit.content.cp/pull/9
https://github.com/ZeitOnline/zeit.cms/pull/10
https://github.com/ZeitOnline/zeit.content.article/pull/2
