### PR TITLE
ZON-3228: Adapt imports for `Result`.

### DIFF
--- a/src/zeit/content/cp/testing.py
+++ b/src/zeit/content/cp/testing.py
@@ -10,7 +10,7 @@ import plone.testing
 import re
 import time
 import transaction
-import zeit.cms.tagging.interfaces
+import zeit.cms.result
 import zeit.cms.testcontenttype.testcontenttype
 import zeit.cms.testing
 import zeit.content.image.testing
@@ -74,7 +74,7 @@ class ElasticsearchMockLayer(plone.testing.Layer):
     def testSetUp(self):
         self['elasticsearch'] = mock.Mock()
         self['elasticsearch'].search.return_value = (
-            zeit.cms.tagging.interfaces.Result())
+            zeit.cms.result.Result())
         zope.interface.alsoProvides(self['elasticsearch'],
                                     zeit.retresco.interfaces.IElasticsearch)
         zope.component.getSiteManager().registerUtility(self['elasticsearch'])

--- a/src/zeit/content/cp/testing.py
+++ b/src/zeit/content/cp/testing.py
@@ -10,7 +10,7 @@ import plone.testing
 import re
 import time
 import transaction
-import zeit.cms.result
+import zeit.cms.interfaces
 import zeit.cms.testcontenttype.testcontenttype
 import zeit.cms.testing
 import zeit.content.image.testing
@@ -74,7 +74,7 @@ class ElasticsearchMockLayer(plone.testing.Layer):
     def testSetUp(self):
         self['elasticsearch'] = mock.Mock()
         self['elasticsearch'].search.return_value = (
-            zeit.cms.result.Result())
+            zeit.cms.interfaces.Result())
         zope.interface.alsoProvides(self['elasticsearch'],
                                     zeit.retresco.interfaces.IElasticsearch)
         zope.component.getSiteManager().registerUtility(self['elasticsearch'])

--- a/src/zeit/content/cp/tests/test_automatic.py
+++ b/src/zeit/content/cp/tests/test_automatic.py
@@ -4,7 +4,6 @@ import lxml.etree
 import mock
 import pysolr
 import zeit.cms.interfaces
-import zeit.cms.result
 import zeit.content.cp.interfaces
 import zeit.content.cp.testing
 import zeit.edit.interfaces
@@ -327,7 +326,7 @@ class AutomaticAreaElasticsearchTest(
         lead.automatic = True
         lead.elasticsearch_raw_query = 'raw'
         lead.automatic_type = 'elasticsearch-query'
-        result = zeit.cms.result.Result(
+        result = zeit.cms.interfaces.Result(
             [{'uniqueId': self.repository['cp'].uniqueId},
              {'uniqueId': 'http://xml.zeit.de/i-do-not-exist'}])
         result.hits = 4711
@@ -358,7 +357,7 @@ class AutomaticAreaTopicpageTest(zeit.content.cp.testing.FunctionalTestCase):
         lead.referenced_topicpage = 'tms-id'
         lead.automatic_type = 'topicpage'
         self.tms.get_topicpage_documents.return_value = (
-            zeit.cms.result.Result())
+            zeit.cms.interfaces.Result())
         IRenderedArea(lead).values()
         self.assertEqual(
             'tms-id', self.tms.get_topicpage_documents.call_args[0][0])

--- a/src/zeit/content/cp/tests/test_automatic.py
+++ b/src/zeit/content/cp/tests/test_automatic.py
@@ -4,7 +4,7 @@ import lxml.etree
 import mock
 import pysolr
 import zeit.cms.interfaces
-import zeit.cms.tagging.interfaces
+import zeit.cms.result
 import zeit.content.cp.interfaces
 import zeit.content.cp.testing
 import zeit.edit.interfaces
@@ -327,7 +327,7 @@ class AutomaticAreaElasticsearchTest(
         lead.automatic = True
         lead.elasticsearch_raw_query = 'raw'
         lead.automatic_type = 'elasticsearch-query'
-        result = zeit.cms.tagging.interfaces.Result(
+        result = zeit.cms.result.Result(
             [{'uniqueId': self.repository['cp'].uniqueId},
              {'uniqueId': 'http://xml.zeit.de/i-do-not-exist'}])
         result.hits = 4711
@@ -358,7 +358,7 @@ class AutomaticAreaTopicpageTest(zeit.content.cp.testing.FunctionalTestCase):
         lead.referenced_topicpage = 'tms-id'
         lead.automatic_type = 'topicpage'
         self.tms.get_topicpage_documents.return_value = (
-            zeit.cms.tagging.interfaces.Result())
+            zeit.cms.result.Result())
         IRenderedArea(lead).values()
         self.assertEqual(
             'tms-id', self.tms.get_topicpage_documents.call_args[0][0])


### PR DESCRIPTION
requires ZeitOnline/zeit.cms#30
