### PR TITLE
ZON-4801: Add operator equal/not-equal to custom query

### DIFF
--- a/src/zeit/content/cp/browser/resources/editor.css
+++ b/src/zeit/content/cp/browser/resources/editor.css
@@ -531,9 +531,6 @@ buttons, we only can get a different label if we override it here. */
   display: none;
 
 }
-.fieldname-query label[for$="..combination_01"]:after {
-  content: "ist gleich";
-}
 
 /* specificity wars, yay */
 #cp-content .fieldname-query .widget .object-reference.landing-zone,

--- a/src/zeit/content/cp/browser/resources/editor.js
+++ b/src/zeit/content/cp/browser/resources/editor.js
@@ -113,7 +113,7 @@ jQuery(document).bind('fragment-ready', function(event) {
     if (! zeit.cms.in_cp_editor()) {
         return;
     }
-    zeit.cms.configure_channel_dropdowns('form.', 'query', '01', '02');
+    zeit.cms.configure_channel_dropdowns('form.', 'query', '02', '03');
     zeit.cms.style_dropdowns(event.target);
 });
 

--- a/src/zeit/content/cp/browser/tests/test_area.py
+++ b/src/zeit/content/cp/browser/tests/test_area.py
@@ -199,7 +199,7 @@ class AreaBrowserTest(
             'query-type-authorships']
         b.getControl('Add Custom Query').click()  # Force a submit
         self.assertEqual(
-            '', b.getControl(name='form.query.0..combination_01').value)
+            '', b.getControl(name='form.query.0..combination_02').value)
 
 
 class TooltipFixture(object):

--- a/src/zeit/content/cp/field.py
+++ b/src/zeit/content/cp/field.py
@@ -5,15 +5,15 @@ import zope.schema.interfaces
 
 class DynamicCombination(zc.form.field.Combination):
 
-    def __init__(self, type_field, type_interface, **kw):
+    def __init__(self, type_field, type_interface, *fields, **kw):
         self.type_field = type_field
         self.type_field.__name__ = "combination_00"
-        self.fields = (type_field,)
+        self.fields = (type_field,) + fields
         self.type_interface = type_interface
         super(zc.form.field.Combination, self).__init__(**kw)
 
     def generate_fields(self, selector):
-        result = []
+        result = list(self.fields[1:])
         field = self.type_interface[selector]
         if zope.schema.interfaces.ICollection.providedBy(field):
             field = field.value_type

--- a/src/zeit/content/cp/interfaces.py
+++ b/src/zeit/content/cp/interfaces.py
@@ -285,6 +285,14 @@ class QueryTypeSource(SimpleDictSource):
     ])
 
 
+class QueryOperatorSource(SimpleDictSource):
+
+    values = collections.OrderedDict([
+        ('eq', _('query-operator-equal')),
+        ('neq', _('query-operator-notequal')),
+    ])
+
+
 class QuerySubRessortSource(zeit.cms.content.sources.SubRessortSource):
 
     def _get_master_value(self, context):
@@ -490,6 +498,9 @@ class IReadArea(zeit.edit.interfaces.IReadContainer):
                 title=_('Custom Query Type'),
                 source=QueryTypeSource(), default='channels'),
             IQueryConditions,
+            zope.schema.Choice(
+                title=_('Custom Query Operator'),
+                source=QueryOperatorSource(), default='eq'),
         ),
         default=(),
         required=False)

--- a/src/zeit/content/cp/tests/test_area.py
+++ b/src/zeit/content/cp/tests/test_area.py
@@ -382,9 +382,9 @@ class CustomQueryTest(zeit.content.cp.testing.FunctionalTestCase):
         source = zeit.cms.content.interfaces.ICommonMetadata['serie'].source(
             None)
         autotest = source.find('Autotest')
-        area.query = (('serie', autotest),)
+        area.query = (('serie', 'eq', autotest),)
         lxml.objectify.deannotate(area.xml, cleanup_namespaces=True)
         self.assertEllipsis(
-            '<query...><condition type="serie">Autotest</condition></query>',
+            '<query...><condition...type="serie">Autotest</condition></query>',
             lxml.etree.tostring(area.xml.query))
-        self.assertEqual((('serie', autotest),), area.query)
+        self.assertEqual((('serie', 'eq', autotest),), area.query)


### PR DESCRIPTION
This mostly involve inserting the additional field and shifting everything "one place to the right".

I'm not _quite_ happy with the nesting due to `additional_clauses`, but I don't have an idea how to flatten it generally. So I hope that elasticsearch flattens it on the server anyway...